### PR TITLE
Add Dollar Ping to portfolio projects

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -5,6 +5,16 @@
 import "./src/env.js";
 
 /** @type {import("next").NextConfig} */
-const config = {};
+const config = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "www.dollarping.com",
+        pathname: "/**",
+      },
+    ],
+  },
+};
 
 export default config;

--- a/site/src/app/(pages)/projects/[id]/page.tsx
+++ b/site/src/app/(pages)/projects/[id]/page.tsx
@@ -42,6 +42,9 @@ export default async function ProjectPage({
       <Card className="w-full max-w-2xl p-4">
         <CardHeader>
           <CardTitle className="text-2xl font-bold">{project.title}</CardTitle>
+          {project.period ? (
+            <p className="text-muted-foreground text-sm">{project.period}</p>
+          ) : null}
           <div className="flex flex-row gap-4">
             {project.tags.map((tag) => (
               <Badge key={tag}>{tag}</Badge>

--- a/site/src/components/projects.tsx
+++ b/site/src/components/projects.tsx
@@ -41,6 +41,9 @@ function ProjectCard({ project }: { readonly project: Project }) {
         </CardHeader>
         <CardContent>
           <CardTitle className="text-xl">{project.title}</CardTitle>
+          {project.period ? (
+            <p className="text-muted-foreground text-sm">{project.period}</p>
+          ) : null}
         </CardContent>
         <CardFooter>
           <div className="flex flex-wrap gap-2">

--- a/site/src/constants/projects.ts
+++ b/site/src/constants/projects.ts
@@ -11,6 +11,30 @@ export type Project = {
   image: string;
   links: ProjectLink[];
   tags: string[];
+  /** Shown on the project card and detail page when set */
+  period?: string;
+};
+
+const dollarping: Project = {
+  id: "dollarping",
+  title: "Dollar Ping",
+  description:
+    "A platform that automates small recurring charges on your credit cards so accounts stay active—helping avoid inactivity closures, reduce mental overhead from tracking many cards, and keep utilization and credit age healthier. Users pick their cards, connect through a secure dashboard with tokenization (full card numbers are not stored on Dollar Ping servers), and choose 6- or 12-month “ping” schedules aligned with bank expectations.",
+  image: "https://www.dollarping.com/dollar-coin.jpg",
+  links: [
+    {
+      name: "Live",
+      url: "https://www.dollarping.com/",
+      icon: "site",
+    },
+    {
+      name: "App",
+      url: "https://app.dollarping.com",
+      icon: "site",
+    },
+  ],
+  tags: ["Next.js", "TypeScript", "FinTech"],
+  period: "Feb 2026 - Mar 2026",
 };
 
 const momopromo: Project = {
@@ -221,6 +245,7 @@ const github_url_converter: Project = {
 };
 
 export const projects: Project[] = [
+  dollarping,
   momopromo,
   custodia,
   scam_scammer,

--- a/site/src/constants/projects.ts
+++ b/site/src/constants/projects.ts
@@ -27,11 +27,6 @@ const dollarping: Project = {
       url: "https://www.dollarping.com/",
       icon: "site",
     },
-    {
-      name: "App",
-      url: "https://app.dollarping.com",
-      icon: "site",
-    },
   ],
   tags: ["Next.js", "TypeScript", "FinTech"],
   period: "Feb 2026 - Mar 2026",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds **Dollar Ping** ([dollarping.com](https://www.dollarping.com/)) as the first item in the portfolio `projects` list so it appears as the most recent project on the home grid.
- Description reflects the product positioning from the live site: automated small charges to keep cards active, security/tokenization, and 6- vs 12-month schedules. Single **Live** link to the marketing site only.
- Introduces an optional `period` field on `Project` and shows it on project cards and `/projects/[id]` pages. Dollar Ping uses **Feb 2026 - Mar 2026** per request.
- Allows the project hero image via Next.js `images.remotePatterns` for `www.dollarping.com` (using their public `dollar-coin.jpg` asset).

## Testing

- `npm install` and `npm run check` in `site/` (lint + `tsc --noEmit`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-480131d6-ec5a-4b3b-a560-8e00819dd7df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-480131d6-ec5a-4b3b-a560-8e00819dd7df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

