### PR TITLE
Add startup sections and refresh project showcase assets

### DIFF
--- a/site/public/images/projects/infinitytool.svg
+++ b/site/public/images/projects/infinitytool.svg
@@ -1,0 +1,23 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#F7F1E8"/>
+  <rect y="0" width="1200" height="88" fill="#FFEF5C"/>
+  <rect x="176" y="20" width="144" height="48" rx="24" fill="white" stroke="black" stroke-width="4"/>
+  <rect x="927" y="20" width="112" height="48" rx="24" fill="#8BE9FD" stroke="black" stroke-width="4"/>
+  <rect x="140" y="140" width="920" height="190" rx="34" fill="white" stroke="black" stroke-width="6"/>
+  <rect x="170" y="190" width="122" height="34" rx="17" fill="#FFEF5C" stroke="black" stroke-width="3"/>
+  <rect x="305" y="190" width="262" height="34" rx="17" fill="#F7F1E8" stroke="black" stroke-width="3"/>
+  <rect x="874" y="184" width="156" height="46" rx="23" fill="white" stroke="black" stroke-width="4"/>
+  <rect x="140" y="360" width="920" height="220" rx="34" fill="#F2E9D8" stroke="black" stroke-width="6"/>
+  <rect x="170" y="400" width="404" height="150" rx="28" fill="#8BE9FD" stroke="black" stroke-width="5"/>
+  <rect x="602" y="400" width="142" height="150" rx="22" fill="#FFEF5C" stroke="black" stroke-width="5"/>
+  <rect x="766" y="400" width="142" height="150" rx="22" fill="white" stroke="black" stroke-width="5"/>
+  <rect x="930" y="400" width="100" height="150" rx="22" fill="#FF8A5B" stroke="black" stroke-width="5"/>
+  <text x="196" y="52" fill="black" font-family="Georgia, serif" font-size="20" font-weight="700" letter-spacing="5">INFINITYTOOL</text>
+  <text x="953" y="51" fill="black" font-family="Georgia, serif" font-size="17" font-weight="700" letter-spacing="3">ALL TOOLS</text>
+  <text x="192" y="214" fill="black" font-family="Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="3">LIVE TOOL</text>
+  <text x="326" y="214" fill="black" font-family="Courier New, monospace" font-size="15" font-weight="700" letter-spacing="2">/TOOL/DISCOVERY</text>
+  <text x="897" y="213" fill="black" font-family="Georgia, serif" font-size="15" font-weight="700" letter-spacing="3">BACK TO GALLERY</text>
+  <text x="176" y="280" fill="black" font-family="Georgia, serif" font-size="64" font-weight="700">INFINITYTOOL</text>
+  <text x="177" y="318" fill="black" font-family="Arial, sans-serif" font-size="24" font-weight="500">A growing library of focused tools with searchable discovery</text>
+  <text x="177" y="347" fill="black" font-family="Arial, sans-serif" font-size="24" font-weight="500">and dedicated pages built for fast repeat use.</text>
+</svg>

--- a/site/public/images/projects/infinitytool.svg
+++ b/site/public/images/projects/infinitytool.svg
@@ -12,12 +12,5 @@
   <rect x="602" y="400" width="142" height="150" rx="22" fill="#FFEF5C" stroke="black" stroke-width="5"/>
   <rect x="766" y="400" width="142" height="150" rx="22" fill="white" stroke="black" stroke-width="5"/>
   <rect x="930" y="400" width="100" height="150" rx="22" fill="#FF8A5B" stroke="black" stroke-width="5"/>
-  <text x="196" y="52" fill="black" font-family="Georgia, serif" font-size="20" font-weight="700" letter-spacing="5">INFINITYTOOL</text>
-  <text x="953" y="51" fill="black" font-family="Georgia, serif" font-size="17" font-weight="700" letter-spacing="3">ALL TOOLS</text>
-  <text x="192" y="214" fill="black" font-family="Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="3">LIVE TOOL</text>
-  <text x="326" y="214" fill="black" font-family="Courier New, monospace" font-size="15" font-weight="700" letter-spacing="2">/TOOL/DISCOVERY</text>
-  <text x="897" y="213" fill="black" font-family="Georgia, serif" font-size="15" font-weight="700" letter-spacing="3">BACK TO GALLERY</text>
   <text x="176" y="280" fill="black" font-family="Georgia, serif" font-size="64" font-weight="700">INFINITYTOOL</text>
-  <text x="177" y="318" fill="black" font-family="Arial, sans-serif" font-size="24" font-weight="500">A growing library of focused tools with searchable discovery</text>
-  <text x="177" y="347" fill="black" font-family="Arial, sans-serif" font-size="24" font-weight="500">and dedicated pages built for fast repeat use.</text>
 </svg>

--- a/site/public/images/projects/studytype.svg
+++ b/site/public/images/projects/studytype.svg
@@ -1,0 +1,15 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#0B1020"/>
+  <rect x="72" y="72" width="1056" height="486" rx="36" fill="#121A2B" stroke="#2D3A59" stroke-width="4"/>
+  <rect x="108" y="108" width="984" height="96" rx="28" fill="#F8FAFC" stroke="#1E293B" stroke-width="4"/>
+  <rect x="108" y="228" width="468" height="294" rx="28" fill="#1D4ED8" stroke="#93C5FD" stroke-width="4"/>
+  <rect x="600" y="228" width="492" height="136" rx="28" fill="#F8FAFC" stroke="#1E293B" stroke-width="4"/>
+  <rect x="600" y="386" width="236" height="136" rx="28" fill="#A7F3D0" stroke="#064E3B" stroke-width="4"/>
+  <rect x="856" y="386" width="236" height="136" rx="28" fill="#FDE68A" stroke="#92400E" stroke-width="4"/>
+  <rect x="146" y="150" width="190" height="30" rx="15" fill="#DBEAFE"/>
+  <rect x="356" y="150" width="248" height="30" rx="15" fill="#E2E8F0"/>
+  <text x="112" y="308" fill="white" font-family="Georgia, serif" font-size="60" font-weight="700">STUDYTYPE</text>
+  <rect x="112" y="420" width="138" height="40" rx="20" fill="#F8FAFC"/>
+  <rect x="264" y="420" width="164" height="40" rx="20" fill="#BFDBFE"/>
+  <rect x="442" y="420" width="92" height="40" rx="20" fill="#F8FAFC"/>
+</svg>

--- a/site/public/images/projects/vercel-redirect.svg
+++ b/site/public/images/projects/vercel-redirect.svg
@@ -1,0 +1,4 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="white"/>
+  <path d="M600 165L870 465H330L600 165Z" fill="black"/>
+</svg>

--- a/site/src/components/footer.tsx
+++ b/site/src/components/footer.tsx
@@ -5,6 +5,7 @@ import {
   FaXTwitter,
   FaBluesky,
   FaInstagram,
+  FaReddit,
 } from "react-icons/fa6";
 import { Separator } from "./ui/separator";
 
@@ -29,6 +30,9 @@ export default function Footer() {
         </Link>
         <Link href="https://www.instagram.com/xavierloeraflores/">
           <FaInstagram className="h-6 w-6" />
+        </Link>
+        <Link href="https://reddit.com/u/xavierloeraflores">
+          <FaReddit className="h-6 w-6" />
         </Link>
       </div>
       <Separator />

--- a/site/src/constants/projects.ts
+++ b/site/src/constants/projects.ts
@@ -225,7 +225,7 @@ const vercel_redirect: Project = {
   title: "Vercel Redirect Template",
   description:
     "A minimal Vercel template for one-click domain redirects that forwards traffic to another site with optional path preservation.",
-  image: "/images/projects/github.png",
+  image: "/images/projects/vercel-redirect.svg",
   links: [
     {
       name: "GitHub",
@@ -267,18 +267,36 @@ const infinitytool: Project = {
   tags: ["Next.js", "Vercel", "Utilities"],
 };
 
+const studytype: Project = {
+  id: "studytype",
+  title: "StudyType",
+  description:
+    "A study tool that helps users retain subject knowledge by repeatedly taking typing tests, combining repetition-based practice with faster typing and AI-generated study sets for premium users.",
+  image: "/images/projects/studytype.svg",
+  links: [
+    {
+      name: "Live",
+      url: "https://www.studytype.app",
+      icon: "site",
+    },
+  ],
+  tags: ["Next.js", "Convex", "Clerk"],
+};
+
+// New projects are added at the top of this list.
 export const projects: Project[] = [
-  momopromo,
-  custodia,
-  scam_scammer,
-  content_moderation,
-  notes,
-  kurios,
-  propslab,
-  mappy,
-  github_url_converter,
-  vercel_redirect,
+  studytype,
   infinitytool,
+  vercel_redirect,
+  github_url_converter,
+  mappy,
+  propslab,
+  kurios,
+  notes,
+  content_moderation,
+  scam_scammer,
+  custodia,
+  momopromo,
 ];
 
 export const projectsMap = new Map<string, Project>(

--- a/site/src/constants/projects.ts
+++ b/site/src/constants/projects.ts
@@ -220,6 +220,32 @@ const github_url_converter: Project = {
   tags: ["React", "Next.js", "Tailwind CSS"],
 };
 
+const vercel_redirect: Project = {
+  id: "vercel-redirect",
+  title: "Vercel Redirect Template",
+  description:
+    "A minimal Vercel template for one-click domain redirects that forwards traffic to another site with optional path preservation.",
+  image: "/images/projects/github.png",
+  links: [
+    {
+      name: "GitHub",
+      url: "https://github.com/xavierloeraflores/vercel-redirect",
+      icon: "github",
+    },
+    {
+      name: "Demo",
+      url: "https://vercel-domain-redirect-demo.vercel.app",
+      icon: "site",
+    },
+    {
+      name: "Deploy",
+      url: "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fxavierloeraflores%2Fvercel-redirect",
+      icon: "link",
+    },
+  ],
+  tags: ["Vercel", "vercel.json", "Redirects"],
+};
+
 export const projects: Project[] = [
   momopromo,
   custodia,
@@ -230,6 +256,7 @@ export const projects: Project[] = [
   propslab,
   mappy,
   github_url_converter,
+  vercel_redirect,
 ];
 
 export const projectsMap = new Map<string, Project>(

--- a/site/src/constants/projects.ts
+++ b/site/src/constants/projects.ts
@@ -246,6 +246,27 @@ const vercel_redirect: Project = {
   tags: ["Vercel", "vercel.json", "Redirects"],
 };
 
+const infinitytool: Project = {
+  id: "infinitytool",
+  title: "InfinityTool",
+  description:
+    "A growing library of focused tools with searchable discovery and dedicated tool pages built for fast repeat use.",
+  image: "/images/projects/infinitytool.svg",
+  links: [
+    {
+      name: "Live",
+      url: "https://www.infinitytool.app/",
+      icon: "site",
+    },
+    {
+      name: "Tools",
+      url: "https://www.infinitytool.app/tools",
+      icon: "link",
+    },
+  ],
+  tags: ["Next.js", "Vercel", "Utilities"],
+};
+
 export const projects: Project[] = [
   momopromo,
   custodia,
@@ -257,6 +278,7 @@ export const projects: Project[] = [
   mappy,
   github_url_converter,
   vercel_redirect,
+  infinitytool,
 ];
 
 export const projectsMap = new Map<string, Project>(


### PR DESCRIPTION
## Summary
- add dedicated startup listings and detail pages alongside employed companies on the home page
- expand company/startup profile data with new responsibilities, projects, and supporting logo assets
- add recent project entries for StudyType, InfinityTool, and Vercel Redirect, with newest projects pinned first
- refresh footer social links and update tRPC lockfile versions

## Testing
- Not run (not requested)