### PR TITLE
Fix Vercel build by pinning Node.js 24

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -78,6 +78,9 @@
         "tailwindcss": "^4.0.15",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.27.0"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/site/package.json
+++ b/site/package.json
@@ -91,5 +91,8 @@
   "ct3aMetadata": {
     "initVersion": "7.39.0"
   },
+  "engines": {
+    "node": "24.x"
+  },
   "packageManager": "npm@10.8.2"
 }


### PR DESCRIPTION
## Summary
- add a Node.js engine requirement of `24.x` to `site/package.json`
- update `site/package-lock.json` to reflect the engine constraint
- align the app with Vercel's supported Node.js runtime to avoid deploy failures

## Testing
- Not run (not requested)